### PR TITLE
fix: generate kid on client side same as on backend

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -50,11 +50,11 @@ jobs:
               uses: google-github-actions/auth@v0
               if: ${{ always() }}
               with:
-                credentials_json: ${{ secrets.GCP_SERVICE_KEY_BQ }}
+                  credentials_json: ${{ secrets.GCP_SERVICE_KEY_BQ }}
             - name: Publish Deployment Metadata
               if: ${{ always() }}
               uses: indykite/metadata-publisher@v0
               with:
-                version: ${{ env.VERSION }}
-                status: ${{ job.status }}
-                bigquery_table: ${{ env.BIGQUERY_TABLE }}
+                  version: ${{ env.VERSION }}
+                  status: ${{ job.status }}
+                  bigquery_table: ${{ env.BIGQUERY_TABLE }}

--- a/grpc/jwt/jwt.go
+++ b/grpc/jwt/jwt.go
@@ -89,6 +89,14 @@ func JWTokenSource(secretKey []byte, pem bool, clientID uuid.UUID) (oauth2.Token
 		return nil, errors.New("jwt: invalid clientID UUID")
 	}
 
+	// Remove user defined kid and generate new one same way as we do on BE
+	// This is micro-optimization on client-side.
+	_ = key.Remove(jwk.KeyIDKey)
+	err = jwk.AssignKeyID(key)
+	if err != nil {
+		return nil, errors.New("failed to assign kid for public key")
+	}
+
 	t := jwt.New()
 	_ = t.Set(jwt.IssuerKey, clientID.String())
 	_ = t.Set(jwt.SubjectKey, clientID.String())


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->

# Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test` passes
- [x] commit message follows [commit guidelines](./doc/guides/commit-message.md#commit-message-guidelines)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

## Affected core subsystem(s)

<!-- Please provide affected core subsystem(s). -->

## Description of change

When user provide their own Public Key, we need to generate KID on our side. But then, lookup by KID doesn't work.
This is fixed in BE, but micro-optimization is added to SDK as well. 
