### PR TITLE
refactor: use updated GitHub org secrets

### DIFF
--- a/.github/workflows/docker-build-go-sdk-tests.yaml
+++ b/.github/workflows/docker-build-go-sdk-tests.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0 - https://github.com/google-github-actions/auth/releases
         id: authentication
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDP }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER_MGMT }}
           service_account: github@${{ env.GCP_PROJECT_ID_MGMT }}.iam.gserviceaccount.com
 
       - name: docker/login

--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: gcloud/auth
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0 - https://github.com/google-github-actions/auth/releases
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDP }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER_MGMT }}
           service_account: github@${{ secrets.GCP_PROJECT_ID_MGMT }}.iam.gserviceaccount.com
 
       - name: Run Integration tests


### PR DESCRIPTION
This PR replaces some current repo secrets usage with org-wide secrets.

[ENG-7525]

[ENG-7525]: https://indykite.atlassian.net/browse/ENG-7525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ